### PR TITLE
bugfix/remove-async: removed async from script

### DIFF
--- a/src/main/resources/site/processors/matomo-report.js
+++ b/src/main/resources/site/processors/matomo-report.js
@@ -68,12 +68,12 @@ exports.responseProcessor = function (req, res) {
     siteRootPath = "";
   }
 
-  res.pageContributions.headEnd.push("<script async defer src=\"" + siteRootPath + "/matomo.js?" + hash + "\"></script>");
+  res.pageContributions.headEnd.push("<script defer src=\"" + siteRootPath + "/matomo.js?" + hash + "\"></script>");
   if (matomoTagManagerContainerId) {
-    res.pageContributions.headEnd.push("<script async defer src=\"" + matomoJavaScriptUrl + "/container_" + matomoTagManagerContainerId + ".js\"></script>");
+    res.pageContributions.headEnd.push("<script defer src=\"" + matomoJavaScriptUrl + "/container_" + matomoTagManagerContainerId + ".js\"></script>");
   }
   if (!matomoTagManagerContainerId) {
-    res.pageContributions.headEnd.push("<script async defer src=\"" + matomoJavaScriptUrl + "/matomo.js\"></script>");
+    res.pageContributions.headEnd.push("<script defer src=\"" + matomoJavaScriptUrl + "/matomo.js\"></script>");
   }
 
   if (trackDisabledJS) {


### PR DESCRIPTION
Met.no got errors because of `_paq.push()` got executed after the script was run. So other scripts was downloaded and run async a bit too fast. This was solved by removing the `async` from the script. 

Roeland, feel free to correct me if the explanation is a bit off. 